### PR TITLE
seperate root build directories

### DIFF
--- a/.buildkite/create-image.sh
+++ b/.buildkite/create-image.sh
@@ -12,7 +12,7 @@ BUCKET_PATH="${BUCKET}/${BUILDKITE_PIPELINE_SLUG}-${BUILDKITE_BRANCH}-${COMMIT}.
 
 gsutil cp disk.raw.tar.gz gs://$BUCKET_PATH
 gcloud compute --project=$PROJECT \
-    images create buildkite-agent-3-11-2-${BUILDKITE_BRANCH}-${COMMIT} \
+    images create buildkite-agent-3-19-0-${BUILDKITE_BRANCH}-${COMMIT} \
     --family=alpine \
     --description="$BUILDKITE_BRANCH $BUILDKITE_COMMIT on $BUILDKITE_REPO ($BUILDKITE_BUILD_URL)" \
     --source-uri=gs://$BUCKET_PATH

--- a/etc/init.d/buildkite-agent
+++ b/etc/init.d/buildkite-agent
@@ -21,7 +21,7 @@ start() {
         echo "Unable to get buildkite-token"
         exit $status
     fi
-    export BUILDKITE_AGENT_ACCESS_TOKEN=$token
+    export BUILDKITE_AGENT_TOKEN=$token
 
     # fetch priority
     priority=$(curl --fail --silent "http://metadata.google.internal/computeMetadata/v1/instance/attributes/buildkite-priority" -H "Metadata-Flavor: Google")
@@ -63,12 +63,22 @@ END
             mkdir --mode 0755 /home/buildkite/$i/builds
             mkdir --mode 0755 /home/buildkite/$i/plugins
             mkdir --mode 0755 /home/buildkite/$i/hooks
+            chown -hR buildkite:buildkite /home/buildkite/$i
         fi
         final_arguments="$arguments --name $name-$i --build-path /home/buildkite/$i/builds --plugins-path /home/buildkite/$i/plugins --hooks-path=/home/buildkite/$i/hooks"
-        nohup sudo --user buildkite /usr/sbin/buildkite-agent start $final_arguments 2>&1 >> /var/log/buildkite.$i.log &
+        nohup sudo --preserve-env=BUILDKITE_AGENT_TOKEN --user buildkite /usr/sbin/buildkite-agent start $final_arguments 2>&1 >> /var/log/buildkite.$i.log &
         sleep 1
         echo $! > /var/run/buildkite.$i.pid
     done
+
+    # check if processes run
+    sleep 1
+    kill -0 $(cat /var/run/buildkite.*.pid) &> /dev/null
+    if [ $? -ne 0 ]; then
+        echo "failed to start buildkite agents"
+        cat /var/log/buildkite.*.log
+        exit 1
+    fi
 
     # start nginx (for health)
     /etc/init.d/nginx start

--- a/etc/init.d/buildkite-agent
+++ b/etc/init.d/buildkite-agent
@@ -5,14 +5,14 @@ depend() {
 }
 
 start() {
-    arguments="--build-path /home/buildkite/builds --plugins-path /home/buildkite/plugins --hooks-path=/home/buildkite/hooks"
+    arguments=""
     # fetch name
     name=$(curl --fail --silent "http://metadata.google.internal/computeMetadata/v1/instance/name" -H "Metadata-Flavor: Google")
     status=$?
     if [ $status -ne 0 ]; then
         name=$(hostname)
     fi
-    arguments="$arguments --name $name-%n"
+    
 
     # fetch token
     token=$(curl --fail --silent "http://metadata.google.internal/computeMetadata/v1/instance/attributes/buildkite-token" -H "Metadata-Flavor: Google")
@@ -21,7 +21,7 @@ start() {
         echo "Unable to get buildkite-token"
         exit $status
     fi
-    arguments="$arguments --token $token"
+    export BUILDKITE_AGENT_ACCESS_TOKEN=$token
 
     # fetch priority
     priority=$(curl --fail --silent "http://metadata.google.internal/computeMetadata/v1/instance/attributes/buildkite-priority" -H "Metadata-Flavor: Google")
@@ -58,7 +58,14 @@ END
     fi
 
     for i in $(seq 1 $agent_count); do
-        nohup sudo --user buildkite /usr/sbin/buildkite-agent start $arguments 2>&1 >> /var/log/buildkite.$i.log &
+        if [ ! -d "/home/buildkite/$i" ]; then
+            mkdir --mode 0755 /home/buildkite/$i
+            mkdir --mode 0755 /home/buildkite/$i/builds
+            mkdir --mode 0755 /home/buildkite/$i/plugins
+            mkdir --mode 0755 /home/buildkite/$i/hooks
+        fi
+        final_arguments="$arguments --name $name-$i --build-path /home/buildkite/$i/builds --plugins-path /home/buildkite/$i/plugins --hooks-path=/home/buildkite/$i/hooks"
+        nohup sudo --user buildkite /usr/sbin/buildkite-agent start $final_arguments 2>&1 >> /var/log/buildkite.$i.log &
         sleep 1
         echo $! > /var/run/buildkite.$i.pid
     done

--- a/install2.sh
+++ b/install2.sh
@@ -135,9 +135,6 @@ cp $SCRIPTPATH/etc/init.d/buildkite-agent /etc/init.d/buildkite-agent
 chmod 0700 /etc/init.d/buildkite-agent
 rc-update add buildkite-agent default
 
-#mkdir --mode 0755 /home/buildkite/builds
-#mkdir --mode 0755 /home/buildkite/plugins
-#mkdir --mode 0755 /home/buildkite/hooks
 chown -hR buildkite:buildkite /home/buildkite
 
 

--- a/install2.sh
+++ b/install2.sh
@@ -135,9 +135,9 @@ cp $SCRIPTPATH/etc/init.d/buildkite-agent /etc/init.d/buildkite-agent
 chmod 0700 /etc/init.d/buildkite-agent
 rc-update add buildkite-agent default
 
-mkdir --mode 0755 /home/buildkite/builds
-mkdir --mode 0755 /home/buildkite/plugins
-mkdir --mode 0755 /home/buildkite/hooks
+#mkdir --mode 0755 /home/buildkite/builds
+#mkdir --mode 0755 /home/buildkite/plugins
+#mkdir --mode 0755 /home/buildkite/hooks
 chown -hR buildkite:buildkite /home/buildkite
 
 


### PR DESCRIPTION
Each agent has its own builds, plugins, hooks folder.
This should overcome some bugs in hooks or plugins that accesses other buildkite agent files.

Additional Changes:
* only start nginx (used for gce health checks) when all agents started correctly
* specify buildkite token in environment variable